### PR TITLE
Added block-based column DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.1.0 (March 4th, 2019)
 
-* Added domain-specific language for configuring Column objects through Template.  This is optional and is backwards compatible.
+* Added two domain-specific language options for configuring Column objects through Template: subclass Template class or pass in block.  This is optional and is backwards compatible.
 
 # 2.0.1 (February 5th, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0 (March 4th, 2019)
+
+* Added domain-specific language for configuring Column objects through Template.  This is optional and is backwards compatible.
+
 # 2.0.1 (February 5th, 2019)
 
 * Updated acts_as_hashable Dependency

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bumblebee (2.0.1)
+    bumblebee (2.1.0)
       acts_as_hashable (~> 1.0)
 
 GEM
@@ -95,10 +95,11 @@ PLATFORMS
 DEPENDENCIES
   bumblebee!
   guard-rspec (~> 4.7)
+  pry
   rspec (~> 3.8)
   rubocop (~> 0.63.1)
   simplecov (~> 0.16.1)
   simplecov-console (~> 0.4.2)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -268,6 +268,31 @@ objects = Bumblebee.parse_csv(data) do |t|
 end
 ````
 
+You can also choose to interact/build templates directly instead of going through the top-level API:
+
+````ruby
+template = Bumblebee::Template.new(columns)
+
+# or
+
+template = Bumblebee::Template.new do |t|
+  t.column :id,    header: 'ID #',
+                   to_object: ->(o) { o['ID #'].to_i }
+
+  t.column :first, header: 'First Name',
+                   to_csv: %i[name first],
+                   to_object: ->(o) { { first: o['First Name'] } }
+end
+````
+
+Template class has the same top-level methods:
+
+````ruby
+csv = template.generate_csv(objects)
+
+objects = template.parse_csv(data)
+````
+
 ## Contributing
 
 ### Development Environment Configuration

--- a/README.md
+++ b/README.md
@@ -244,6 +244,30 @@ The two main methods:
 
 also accept custom options that [Ruby's CSV::new](https://ruby-doc.org/stdlib-2.6/libdoc/csv/rdoc/CSV.html#method-c-new) accepts.  The only caveat is that Bumblebee needs headers for its mapping, so it overrides the header options.
 
+#### Template DSL
+
+You can choose to pass in a block for template/column specification if you would rather prefer a code-first approach over a configuration-first approach.  For example:
+
+````ruby
+csv = Bumblebee.generate_csv(objects) do |t|
+  t.column :id,    header: 'ID #',
+                   to_object: ->(o) { o['ID #'].to_i }
+
+  t.column :first, header: 'First Name',
+                   to_csv: %i[name first],
+                   to_object: ->(o) { { first: o['First Name'] } }
+end
+
+objects = Bumblebee.parse_csv(data) do |t|
+  t.column :id,    header: 'ID #',
+                   to_object: ->(o) { o['ID #'].to_i }
+
+  t.column :first, header: 'First Name',
+                   to_csv: %i[name first],
+                   to_object: ->(o) { { first: o['First Name'] } }
+end
+````
+
 ## Contributing
 
 ### Development Environment Configuration

--- a/bumblebee.gemspec
+++ b/bumblebee.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('acts_as_hashable', '~>1.0')
 
   s.add_development_dependency('guard-rspec', '~>4.7')
+  s.add_development_dependency('pry')
   s.add_development_dependency('rspec', '~> 3.8')
   s.add_development_dependency('rubocop', '~>0.63.1')
   s.add_development_dependency('simplecov', '~>0.16.1')

--- a/lib/bumblebee/bumblebee.rb
+++ b/lib/bumblebee/bumblebee.rb
@@ -19,12 +19,56 @@ require_relative 'template'
 # procedural way using these.
 module Bumblebee
   class << self
-    def generate_csv(columns, objects, options = {})
-      ::Bumblebee::Template.new(columns).generate_csv(objects, options)
+    # Two signatures for consumption:
+    #
+    # ::Bumblebee.generate_csv(columns = [], objects = [], options = {})
+    #
+    # or
+    #
+    # ::Bumblebee.generate_csv(objects = [], options = {}) do |t|
+    #   t.column :id, header: 'ID #'
+    #   t.column :first, header: 'First Name'
+    # end
+    def generate_csv(*args, &block)
+      if block_given?
+        objects = args[0] || []
+        options = args[1] || {}
+      else
+        objects = args[1] || []
+        options = args[2] || {}
+      end
+
+      template(args, &block).generate_csv(objects, options)
     end
 
-    def parse_csv(columns, string, options = {})
-      ::Bumblebee::Template.new(columns).parse_csv(string, options)
+    # Two signatures for consumption:
+    #
+    # ::Bumblebee.parse_csv(columns = [], string = '', options = {})
+    #
+    # or
+    #
+    # ::Bumblebee.parse_csv(string = '', options = {}) do |t|
+    #   t.column :id, header: 'ID #'
+    #   t.column :first, header: 'First Name'
+    # end
+    def parse_csv(*args, &block)
+      if block_given?
+        string  = args[0] || ''
+        options = args[1] || {}
+      else
+        string  = args[1] || ''
+        options = args[2] || {}
+      end
+
+      template(args, &block).parse_csv(string, options)
+    end
+
+    private
+
+    def template(args, &block)
+      columns = block_given? ? [] : (args[0] || [])
+
+      ::Bumblebee::Template.new(columns, &block)
     end
   end
 end

--- a/lib/bumblebee/template.rb
+++ b/lib/bumblebee/template.rb
@@ -12,10 +12,28 @@ module Bumblebee
   # generate_csv: take in an array of objects and return a string (CSV contents)
   # parse_csv: take in a string and return an array of OpenStruct objects
   class Template
+    class << self
+      def columns
+        @columns ||= []
+      end
+
+      def column(field, opts = {})
+        columns << ::Bumblebee::Column.make(opts.merge(field: field))
+
+        self
+      end
+
+      def all_columns
+        ancestors.reverse_each.inject([]) do |arr, ancestor|
+          ancestor < ::Bumblebee::Template ? arr + ancestor.columns : arr
+        end
+      end
+    end
+
     attr_reader :columns
 
     def initialize(columns = [], &block)
-      @columns = ::Bumblebee::Column.array(columns)
+      @columns = self.class.all_columns + ::Bumblebee::Column.array(columns)
 
       return unless block_given?
 

--- a/lib/bumblebee/template.rb
+++ b/lib/bumblebee/template.rb
@@ -14,8 +14,22 @@ module Bumblebee
   class Template
     attr_reader :columns
 
-    def initialize(columns = [])
+    def initialize(columns = [], &block)
       @columns = ::Bumblebee::Column.array(columns)
+
+      return unless block_given?
+
+      if block.arity == 1
+        yield self
+      else
+        instance_eval(&block)
+      end
+    end
+
+    # New DSL method to use for adding columns
+    def column(field, opts = {})
+      @columns << ::Bumblebee::Column.make(opts.merge(field: field))
+      self
     end
 
     # Return array of strings (headers)

--- a/lib/bumblebee/version.rb
+++ b/lib/bumblebee/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Bumblebee
-  VERSION = '2.0.1'
+  VERSION = '2.1.0'
 end

--- a/spec/bumblebee/bumblebee_spec.rb
+++ b/spec/bumblebee/bumblebee_spec.rb
@@ -35,8 +35,18 @@ describe ::Bumblebee do
 
   let(:quoted_csv) { "\"name\",\"dob\"\n\"Matt\",\"1901-01-03\"\n\"Nathan\",\"1931-09-03\"\n" }
 
-  it 'should generate a csv' do
+  it 'should generate a csv using column argument' do
     actual = Bumblebee.generate_csv(columns, people)
+
+    expect(actual).to eq(csv)
+  end
+
+  it 'should generate a csv using block' do
+    actual = Bumblebee.generate_csv(people) do |t|
+      columns.each do |column|
+        t.column column[:field]
+      end
+    end
 
     expect(actual).to eq(csv)
   end
@@ -51,8 +61,18 @@ describe ::Bumblebee do
     expect(actual).to eq(quoted_csv)
   end
 
-  it 'should parse a csv' do
+  it 'should parse a csv using columns argument' do
     objects = Bumblebee.parse_csv(columns, csv)
+
+    expect(objects).to eq(people)
+  end
+
+  it 'should parse a csv using columns block' do
+    objects = Bumblebee.parse_csv(csv) do |t|
+      columns.each do |column|
+        t.column column[:field]
+      end
+    end
 
     expect(objects).to eq(people)
   end

--- a/spec/bumblebee/template_spec.rb
+++ b/spec/bumblebee/template_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2018-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe ::Bumblebee::Template do
+  let(:field) { :id }
+  let(:opts) { { header: 'ID #' } }
+
+  context 'with a blank template' do
+    let(:template) { ::Bumblebee::Template.new }
+
+    subject { template }
+
+    it '#column should add a column' do
+      subject.column(field, opts)
+
+      expect(subject.columns.length).to eq(1)
+      expect(subject.columns.first.field).to eq(field)
+      expect(subject.columns.first.header).to eq(opts[:header])
+    end
+  end
+
+  describe '#initialize' do
+    specify 'that initialization accepts a block (with arity) for column creation' do
+      template = ::Bumblebee::Template.new do |t|
+        t.column field, opts
+      end
+
+      expect(template.columns.length).to eq(1)
+      expect(template.columns.first.field).to eq(field)
+      expect(template.columns.first.header).to eq(opts[:header])
+    end
+
+    specify 'that initialization accepts a block (without arity) for column creation' do
+      template = ::Bumblebee::Template.new do
+        column :id, header: 'ID #'
+      end
+
+      expect(template.columns.length).to eq(1)
+      expect(template.columns.first.field).to eq(field)
+      expect(template.columns.first.header).to eq(opts[:header])
+    end
+  end
+end

--- a/spec/bumblebee/template_spec.rb
+++ b/spec/bumblebee/template_spec.rb
@@ -48,4 +48,25 @@ describe ::Bumblebee::Template do
       expect(template.columns.first.header).to eq(opts[:header])
     end
   end
+
+  describe 'subclassing' do
+    class PersonTemplate < ::Bumblebee::Template
+      column :id, header: 'ID #'
+    end
+
+    class CompletePersonTemplate < PersonTemplate
+      column :first, header: 'First Name'
+    end
+
+    it 'should use class-level declared columns in the correct parenting hierarchical order' do
+      template = CompletePersonTemplate.new
+
+      expect(template.columns.length).to eq(2)
+      expect(template.columns.first.field).to eq(:id)
+      expect(template.columns.first.header).to eq('ID #')
+
+      expect(template.columns.last.field).to eq(:first)
+      expect(template.columns.last.header).to eq('First Name')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@
 #
 
 require 'stringio'
+require 'pry'
 
 require 'simplecov'
 require 'simplecov-console'


### PR DESCRIPTION
There is a use-case where it makes sense to embed/inline column configuration because column configuration can contain lambdas (which cannot be easily read through file-based configuration strategies.)  In this case it may be easier to use a first-class DSL to build columns instead.  This PR provides two simple interfaces:

1. Template generation accepts a block in order to build columns up
2. Template can be sub-classed with columns directly added to the class using the column directive